### PR TITLE
Use top-left corner of element in visibility calculation

### DIFF
--- a/src/ggrc/assets/javascripts/plugins/tooltip.js
+++ b/src/ggrc/assets/javascripts/plugins/tooltip.js
@@ -35,9 +35,7 @@
    */
   function isElementVisible(el) {
     const bRect = el.getBoundingClientRect();
-    const centerX = Math.round(bRect.x + bRect.width / 2);
-    const centerY = Math.round(bRect.y + bRect.height / 2);
-    const topEl = document.elementFromPoint(centerX, centerY);
+    const topEl = document.elementFromPoint(bRect.x, bRect.y);
     return topEl && (el === topEl || isChildOf(topEl, el));
   }
 


### PR DESCRIPTION
This is done to fix an issue when most of the bounding rect of an
element is hidden by overflow:hidden of parnet element.