### PR TITLE
Use either new or old style locator for 3-dots dropdowns

### DIFF
--- a/test/selenium/src/lib/constants/locator.py
+++ b/test/selenium/src/lib/constants/locator.py
@@ -935,14 +935,11 @@ class CommonDropdownMenu(object):
 
 class CommonDropdown3bbsInfoWidget(CommonDropdownMenu):
   """Locators for common settings 3BBS dropdown on Info widget and Info page.
- """
-  _INFO_3BBS_DROPDOWN_BUTTON_XPATH = (
-      Common.INFO_WIDGET_XPATH + "//*[contains(@class,'dropdown-menu')]")
-  _INFO_3BBS_DROPDOWN_XPATH = (
-      Common.INFO_WIDGET_XPATH +
-      "//ul[contains(@class,'dropdown-menu three-dots-list')]")
-  INFO_WDG_3BBS_DD_BTN_XPATH = (By.XPATH, _INFO_3BBS_DROPDOWN_BUTTON_XPATH)
-  INFO_WDG_3BBS_DD_XPTAH = (By.XPATH, _INFO_3BBS_DROPDOWN_XPATH)
+  """
+  _INFO_3BBS_DD_XPATH = (Common.INFO_WIDGET_XPATH +
+      "//*[contains(@class,'three-dots-list') or "  # old style
+      "contains(@class, 'tree-action-list-items')]")  # new style
+  INFO_WDG_3BBS_DD_XPATH = (By.XPATH, _INFO_3BBS_DD_XPATH)
 
 
 class AuditsDropdown3bbsInfoWidget(CommonDropdown3bbsInfoWidget):

--- a/test/selenium/src/lib/element/widget_info.py
+++ b/test/selenium/src/lib/element/widget_info.py
@@ -17,9 +17,7 @@ class CommonInfoDropdownSettings(elements_list.DropdownMenu):
 
   def __init__(self, driver):
     super(CommonInfoDropdownSettings, self).__init__(
-        driver, self._locators.INFO_WDG_3BBS_DD_XPTAH)
-    self.dropdown_button = base.Button(
-        self._driver, self._locators.INFO_WDG_3BBS_DD_BTN_XPATH)
+        driver, self._locators.INFO_WDG_3BBS_DD_XPATH)
 
   def select_open(self):
     """Select open button in 3BBS dropdown modal."""
@@ -75,7 +73,7 @@ class Programs(CommonInfoDropdownSettings):
   """Programs 3BBS button/dropdown settings on Info pages and Info panels."""
 
 
-class Controls(Snapshots):
+class Controls(CommonInfoDropdownSettings):
   """Controls 3BBS button/dropdown settings on Info pages and Info panels."""
 
 


### PR DESCRIPTION
PR https://github.com/google/ggrc-core/pull/7464 has changed parent locator for 3-dots dropdown in snapshot info panel view. Info page and usual info panel views remain as they were.
I think the solution of using either of two locators (as done in this PR) is fine for the following reason:
1. "three-dots-list" is old-style and is being replaced with "tree-action-list-items" view by view (it is currently used in about 10 views). But some views still contain old locator. If tests will chose a locator based on "widget.is_snapshoted_panel" property we will to have to update the condition after developers will update locator on other views.
2. it's not simple to decide where to put such condition in test code. Classes inside "widget_info.py" represent both snapshotted and ordinary widgets. They don't have access to instance of Widget class so can't check "is_snapshoted_panel" property. It might be possible to set parent locator for CommonInfoDropdownSettings from InfoWidget class but it would require some refactoring that is probably unnecessary.

@SergeyRabtsau please review

Notes:
* Line with "dropdown_button" was removed as it's unused.
* Parent class for "Controls" class was changed to "CommonInfoDropdownSettings" from "Snapshots" because most of classes in this file are used for both snapshottable or ordinary objects.